### PR TITLE
Add ECL support: replace osicat with uiop for env var.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ tested. Please, report bugs either on
 [SourceForge's](https://sourceforge.net/p/cl-tui/tickets/) issue tracker.
 
 Supported implementations are SBCL, CCL. I want to also support ECL and CLISP
-but ECL currently can't build osicat (investigated by osicat developers) and
+but ~~ECL currently can't build osicat (investigated by osicat developers)~~ and
 CLISP had a lot of issues with ncurses. Any help with CLISP is appreciated.
+
+> ryo's note: replaced `osicat` with `uiop:getenv`, so even on ECL, it shall
+> be able to compile. (tested on alpine and macOS)
 
 `cl-tui` is supposed to be a complete abstraction so if you have to use
 `cl-charms` directly for some reason please submit an issue describing your use-case.

--- a/cl-tui.asd
+++ b/cl-tui.asd
@@ -21,4 +21,5 @@
                  anaphora
                  split-sequence
                  cl-containers
-                 osicat))
+                 ;; osicat
+		 ))

--- a/src/cl-tui.lisp
+++ b/src/cl-tui.lisp
@@ -8,7 +8,11 @@
   (when *running*
     (error "Screen is already initialized"))
   (setf *running* t)
-  (sunless (osicat:environment-variable "ESCDELAY")
+  (sunless (uiop:getenv "ESCDELAY")
+    ;; ryo's note: old `cl-tui' use `osicat' to get env var,
+    ;; here replaced the `osicat' with `uiop:getenv'
+    ;; no need for `osicat' (possibly)
+    ;; (osicat:environment-variable "ESCDELAY")
     (setf it "25"))
   (charms/ll:initscr)
   (sunless *non-blocking-window*


### PR DESCRIPTION
On ECL (alpine `apk add ecl`), load `cl-tui` will fail on loading `osicat` with error at:

```
error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
   19 | #define _64_BIT_VALUE_FITS_SIGNED_P(value) ( (value) <= 0x7FFFFFFFFFFFFFFFLL )
      |                                              ~~~~~~~~^~~~~~~~~~~~~~~~~~~~
```

not known if it is related with ECL error or something else, but if replacing the only `osicat` reference in `src/cl-tui.lisp`, aka:

```lisp
(sunless (osicat:environment-variable "ESCDELAY")
```

with

```lisp
(sunless (uiop:getenv "ESCDELAY")
```

it shall need no `osicat` package to do the almost the same thing.

Not know if they will perform differently or if this will bring some loss to the performance.